### PR TITLE
Add content handling and tests to ClientProxyBase

### DIFF
--- a/ClientProxyBase/ClientProxyBase.cs
+++ b/ClientProxyBase/ClientProxyBase.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using Newtonsoft.Json;
 using SimpleResults;
 
 namespace ClientProxyBase
 {
+    using System.Collections;
     using System.Collections.Generic;
     using System.IO;
     using System.Net;
@@ -64,24 +66,7 @@ namespace ClientProxyBase
 
             return result;
         }
-
-        /// <summary>
-        /// Handles the response.
-        /// </summary>
-        /// <param name="responseMessage">The response message.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns></returns>
-        /// <exception cref="System.InvalidOperationException"></exception>
-        /// <exception cref="System.UnauthorizedAccessException"></exception>
-        /// <exception cref="InvalidDataException"></exception>
-        /// <exception cref="System.Exception">An internal error has occurred
-        /// or
-        /// An internal error has occurred</exception>
-        /// <exception cref="InvalidOperationException"></exception>
-        /// <exception cref="UnauthorizedAccessException"></exception>
-        /// <exception cref="Exception">An internal error has occurred
-        /// or
-        /// An internal error has occurred</exception>
+        
         protected virtual async Task<Result<String>> HandleResponseX(HttpResponseMessage responseMessage,
                                                                            CancellationToken cancellationToken) {
 
@@ -102,6 +87,25 @@ namespace ClientProxyBase
             }
 
             return Result.Success<String>(content);
+        }
+
+        protected virtual ResponseData<T> HandleResponseContent<T>(String content)
+        {
+            if (String.IsNullOrEmpty(content))
+            {
+                T data = default(T);
+                if (typeof(IEnumerable).IsAssignableFrom(typeof(T)))
+                {
+                    data = (T)Activator.CreateInstance(typeof(List<>).MakeGenericType(typeof(T).GetGenericArguments()));
+                }
+                else
+                {
+                    data = (T)Activator.CreateInstance(typeof(T));
+                }
+
+                return new ResponseData<T> { Data = data };
+            }
+            return JsonConvert.DeserializeObject<ResponseData<T>>(content);
         }
 
         #endregion

--- a/ClientProxyBase/ClientProxyBase.csproj
+++ b/ClientProxyBase/ClientProxyBase.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SimpleResults" Version="3.0.0" />
   </ItemGroup>
 

--- a/ClientProxyBase/ResponseData.cs
+++ b/ClientProxyBase/ResponseData.cs
@@ -1,0 +1,6 @@
+﻿namespace ClientProxyBase;
+
+public class ResponseData<T>
+{
+    public T Data { get; set; }
+}

--- a/Shared.Tests/ClientProxyBaseTests.cs
+++ b/Shared.Tests/ClientProxyBaseTests.cs
@@ -11,11 +11,11 @@ namespace Shared.Tests
     using System.Net;
     using System.Net.Http;
     using System.Threading;
+    using Microsoft.VisualStudio.TestPlatform.TestHost;
     using Shouldly;
     using Xunit;
 
-    public partial class SharedTests
-    {
+    public partial class SharedTests {
         [Theory]
         [InlineData(HttpStatusCode.OK)]
         [InlineData(HttpStatusCode.Created)]
@@ -28,12 +28,12 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.AlreadyReported)]
         [InlineData(HttpStatusCode.IMUsed)]
 
-        public async Task ClientProxyBase_HandleResponseX_SuccessStatus(HttpStatusCode statusCode){
+        public async Task ClientProxyBase_HandleResponseX_SuccessStatus(HttpStatusCode statusCode) {
             String responseContent = $"Content - {statusCode}";
             HttpResponseMessage response = new HttpResponseMessage(statusCode);
             response.Content = new StringContent(responseContent);
             TestClient proxybase = new TestClient(new HttpClient());
-            Result<String> result  = await proxybase.Test_HandleResponseX(response, CancellationToken.None);
+            Result<String> result = await proxybase.Test_HandleResponseX(response, CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();
             result.Data.ShouldBe(responseContent);
         }
@@ -50,8 +50,7 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.AlreadyReported)]
         [InlineData(HttpStatusCode.IMUsed)]
 
-        public async Task ClientProxyBase_HandleResponse_SuccessStatus(HttpStatusCode statusCode)
-        {
+        public async Task ClientProxyBase_HandleResponse_SuccessStatus(HttpStatusCode statusCode) {
             String responseContent = $"Content - {statusCode}";
             HttpResponseMessage response = new HttpResponseMessage(statusCode);
             response.Content = new StringContent(responseContent);
@@ -64,7 +63,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.SwitchingProtocols, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.Processing, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.EarlyHints, ResultStatus.Failure)]
-        public async Task ClientProxyBase_HandleResponseX_1xx_ErrorStatus(HttpStatusCode statusCode, ResultStatus resultStatus){
+        public async Task ClientProxyBase_HandleResponseX_1xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                          ResultStatus resultStatus) {
             await TestMethod_HandleResponseX(statusCode, resultStatus);
         }
 
@@ -73,8 +73,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.SwitchingProtocols, typeof(Exception))]
         [InlineData(HttpStatusCode.Processing, typeof(Exception))]
         [InlineData(HttpStatusCode.EarlyHints, typeof(Exception))]
-        public async Task ClientProxyBase_HandleResponse_1xx_ErrorStatus(HttpStatusCode statusCode, Type expectedException)
-        {
+        public async Task ClientProxyBase_HandleResponse_1xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                         Type expectedException) {
             await TestMethod_HandleResponse(statusCode, expectedException);
         }
 
@@ -93,8 +93,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.TemporaryRedirect, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.RedirectKeepVerb, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.PermanentRedirect, ResultStatus.Failure)]
-        public async Task ClientProxyBase_HandleResponseX_3xx_ErrorStatus(HttpStatusCode statusCode, ResultStatus resultStatus)
-        {
+        public async Task ClientProxyBase_HandleResponseX_3xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                          ResultStatus resultStatus) {
             await TestMethod_HandleResponseX(statusCode, resultStatus);
         }
 
@@ -113,8 +113,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.TemporaryRedirect, typeof(Exception))]
         [InlineData(HttpStatusCode.RedirectKeepVerb, typeof(Exception))]
         [InlineData(HttpStatusCode.PermanentRedirect, typeof(Exception))]
-        public async Task ClientProxyBase_HandleResponse_3xx_ErrorStatus(HttpStatusCode statusCode, Type expectedException)
-        {
+        public async Task ClientProxyBase_HandleResponse_3xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                         Type expectedException) {
             await TestMethod_HandleResponse(statusCode, expectedException);
         }
 
@@ -146,8 +146,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.TooManyRequests, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.RequestHeaderFieldsTooLarge, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.UnavailableForLegalReasons, ResultStatus.Failure)]
-        public async Task ClientProxyBase_HandleResponseX_4xx_ErrorStatus(HttpStatusCode statusCode, ResultStatus resultStatus)
-        {
+        public async Task ClientProxyBase_HandleResponseX_4xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                          ResultStatus resultStatus) {
             await TestMethod_HandleResponseX(statusCode, resultStatus);
         }
 
@@ -179,8 +179,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.TooManyRequests, typeof(Exception))]
         [InlineData(HttpStatusCode.RequestHeaderFieldsTooLarge, typeof(Exception))]
         [InlineData(HttpStatusCode.UnavailableForLegalReasons, typeof(Exception))]
-        public async Task ClientProxyBase_HandleResponse_4xx_ErrorStatus(HttpStatusCode statusCode, Type expectedException)
-        {
+        public async Task ClientProxyBase_HandleResponse_4xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                         Type expectedException) {
             await TestMethod_HandleResponse(statusCode, expectedException);
         }
 
@@ -196,8 +196,8 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.LoopDetected, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.NotExtended, ResultStatus.Failure)]
         [InlineData(HttpStatusCode.NetworkAuthenticationRequired, ResultStatus.Failure)]
-        public async Task ClientProxyBase_HandleResponseX_5xx_ErrorStatus(HttpStatusCode statusCode, ResultStatus resultStatus)
-        {
+        public async Task ClientProxyBase_HandleResponseX_5xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                          ResultStatus resultStatus) {
             await TestMethod_HandleResponseX(statusCode, resultStatus);
         }
 
@@ -213,25 +213,116 @@ namespace Shared.Tests
         [InlineData(HttpStatusCode.LoopDetected, typeof(Exception))]
         [InlineData(HttpStatusCode.NotExtended, typeof(Exception))]
         [InlineData(HttpStatusCode.NetworkAuthenticationRequired, typeof(Exception))]
-        public async Task ClientProxyBase_HandleResponse_5xx_ErrorStatus(HttpStatusCode statusCode, Type expectedException)
-        {
+        public async Task ClientProxyBase_HandleResponse_5xx_ErrorStatus(HttpStatusCode statusCode,
+                                                                         Type expectedException) {
             await TestMethod_HandleResponse(statusCode, expectedException);
         }
 
-        private async Task TestMethod_HandleResponseX(HttpStatusCode statusCode, ResultStatus resultStatus)
-        {
+        private async Task TestMethod_HandleResponseX(HttpStatusCode statusCode,
+                                                      ResultStatus resultStatus) {
             var proxybase = new TestClient(new HttpClient());
             var result = await proxybase.Test_HandleResponseX(new HttpResponseMessage(statusCode), CancellationToken.None);
             result.Status.ShouldBe(resultStatus);
         }
 
-        private async Task TestMethod_HandleResponse(HttpStatusCode statusCode, Type expectedException)
-        {
+        private async Task TestMethod_HandleResponse(HttpStatusCode statusCode,
+                                                     Type expectedException) {
             var proxybase = new TestClient(new HttpClient());
-            var exception = Should.Throw<Exception>(async() => {
-                await proxybase.Test_HandleResponse(new HttpResponseMessage(statusCode), CancellationToken.None);
-            });
+            var exception = Should.Throw<Exception>(async () => { await proxybase.Test_HandleResponse(new HttpResponseMessage(statusCode), CancellationToken.None); });
             exception.ShouldBeOfType(expectedException);
+        }
+
+        [Fact]
+        public void HandleResponseContent_NullContent_ReturnsDefaultList() {
+            // Arrange
+            string content = null;
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<List<ApiResourceDetails>>(content);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+            result.Data.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void HandleResponseContent_NullContent_ReturnsDefaultObject() {
+            // Arrange
+            string content = null;
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<ApiResourceDetails>(content);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void HandleResponseContent_EmptyContent_ReturnsDefaultList() {
+            // Arrange
+            string content = string.Empty;
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<List<ApiResourceDetails>>(content);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+            result.Data.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void HandleResponseContent_EmptyContent_ReturnsDefaultObject() {
+            // Arrange
+            string content = string.Empty;
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<ApiResourceDetails>(content);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void HandleResponseContent_ValidJsonContent_ReturnsDeserializedObject() {
+            // Arrange
+            string json = "{ \"Data\": { \"name\": \"test\", \"description\": \"test description\" } }";
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<ApiResourceDetails>(json);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+            result.Data.name.ShouldBe("test");
+            result.Data.description.ShouldBe("test description");
+        }
+
+        [Fact]
+        public void HandleResponseContent_ValidJsonContent_ReturnsDeserializedList() {
+            // Arrange
+            string json = "{ \"Data\": [{ \"name\": \"test1\", \"description\": \"test description 1\" }, { \"name\": \"test2\", \"description\": \"test description 2\" }] }";
+            TestClient proxybase = new TestClient(new HttpClient());
+
+            // Act
+            var result = proxybase.Test_HandleResponseContent<List<ApiResourceDetails>>(json);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Data.ShouldNotBeNull();
+            result.Data.Count.ShouldBe(2);
+            result.Data[0].name.ShouldBe("test1");
+            result.Data[0].description.ShouldBe("test description 1");
+            result.Data[1].name.ShouldBe("test2");
+            result.Data[1].description.ShouldBe("test description 2");
         }
     }
 
@@ -246,5 +337,16 @@ namespace Shared.Tests
         public async Task<Result<String>> Test_HandleResponseX(HttpResponseMessage responseMessage, CancellationToken cancellationToken){
             return await this.HandleResponseX(responseMessage, cancellationToken);
         }
+
+        public ResponseData<T> Test_HandleResponseContent<T>(String content)
+        {
+            return this.HandleResponseContent<T>(content);
+        }
+    }
+
+    public class ApiResourceDetails
+    {
+        public string name { get; set; }
+        public string description { get; set; }
     }
 }


### PR DESCRIPTION
Introduce `HandleResponseContent<T>` for deserializing response content. Update `HandleResponseX` for improved functionality. Add `Newtonsoft.Json` and `SimpleResults` package references. Enhance `SharedTests` with tests for new content handling methods. Introduce `ApiResourceDetails` and `ResponseData<T>` classes for structured data handling.