### PR TITLE
Increase max events read in ReadStreamAsync

### DIFF
--- a/Shared.EventStore/EventStore/EventStoreContext.cs
+++ b/Shared.EventStore/EventStore/EventStoreContext.cs
@@ -185,7 +185,7 @@ namespace Shared.EventStore.EventStore
             try {
                 do {
                     response = this.EventStoreClient.ReadStreamAsync(Direction.Forwards, streamName,
-                        StreamPosition.FromInt64(fromVersion), 2, resolveLinkTos: true, deadline: this.Deadline,
+                        StreamPosition.FromInt64(fromVersion), Int32.MaxValue, resolveLinkTos: true, deadline: this.Deadline,
                         cancellationToken: cancellationToken);
 
                     // Check the read state


### PR DESCRIPTION
Updated the `ReadStreamAsync` method in `EventStoreContext.cs` to change the maximum number of events read from `2` to `Int32.MaxValue`. This allows for reading all available events from the specified stream, enhancing data retrieval capabilities.