### PR TITLE
Add unit test for event handler failure and improve error handling

### DIFF
--- a/Shared.EventStore.Tests/EventDispatchHelperTests.cs
+++ b/Shared.EventStore.Tests/EventDispatchHelperTests.cs
@@ -41,4 +41,26 @@ public class EventDispatchHelperTests{
         dispatchResult.IsFailed.ShouldBeTrue();
         
     }
+
+    [Fact]
+    public async Task EventDispatchHelper_DispatchToHandlers_HandlersFail_ErrorThrown()
+    {
+        AggregateNameSetEvent @event = new AggregateNameSetEvent(TestData.AggregateId, TestData.EventId, TestData.EstateName);
+        List<IDomainEventHandler> handlers = new List<IDomainEventHandler>();
+        Mock<IDomainEventHandler> domainEventHandler = new Mock<IDomainEventHandler>();
+        domainEventHandler.Setup(s => s.Handle(It.IsAny<IDomainEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure("Error Message 1"));
+        Mock<IDomainEventHandler> domainEventHandler2 = new Mock<IDomainEventHandler>();
+        domainEventHandler2.Setup(s => s.Handle(It.IsAny<IDomainEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(new List<String>() {
+                "Error Message 2",
+                "Error Message 3"
+            }));
+        handlers.Add(domainEventHandler.Object);
+        handlers.Add(domainEventHandler2.Object);
+        Result dispatchResult = await @event.DispatchToHandlers(handlers, CancellationToken.None);
+        dispatchResult.IsFailed.ShouldBeTrue();
+        dispatchResult.Message.ShouldBe("One or more event handlers have failed. Error Messages [Error Message 1\r\nError Message 2\r\nError Message 3]");
+
+    }
 }

--- a/Shared.EventStore/SubscriptionWorker/EventDispatchHelper.cs
+++ b/Shared.EventStore/SubscriptionWorker/EventDispatchHelper.cs
@@ -34,8 +34,15 @@ namespace Shared.EventStore.SubscriptionWorker
             {
                 Result[] results = await all;
                 if (results.Any(r => r.IsFailed)) {
-                    IEnumerable<String> failedResults = results.Where(r => r.IsFailed).Select(r => r.Message);
-                    String errors = String.Join(Environment.NewLine, failedResults);
+                    var failedResults = results.Where(r => r.IsFailed && String.IsNullOrEmpty(r.Message) == false).Select(r => r.Message).ToList();
+                    var failedResults2 = results.Where(r => r.IsFailed).Select(r => r.Errors).ToList();
+                    var masterList = new List<String>();
+                    masterList.AddRange(failedResults);
+                    foreach (IEnumerable<String> enumerable in failedResults2) {
+                        masterList.AddRange(enumerable);
+                    }
+                    
+                    String errors = String.Join(Environment.NewLine, masterList);
                     // We have a failed result so need to do something with it
                     return Result.Failure($"One or more event handlers have failed. Error Messages [{errors}]");
                 }


### PR DESCRIPTION
Introduces a new unit test `EventDispatchHelper_DispatchToHandlers_HandlersFail_ErrorThrown` to verify that multiple event handler failures return the correct error messages.

Modifies error handling in `EventDispatchHelper.cs` to ensure that both error messages and additional errors from failed results are collected and formatted properly in the final error message.