### PR TITLE
Enhance domain event handler resolution and tests

### DIFF
--- a/Shared.EventStore.Tests/DomainEventHandlerResolverTests.cs
+++ b/Shared.EventStore.Tests/DomainEventHandlerResolverTests.cs
@@ -14,18 +14,22 @@ namespace Shared.EventStore.Tests
         [Fact]
         public void DomainEventHandlerResolver_GetDomainEventHandlers_HandlerResolved(){
             Dictionary<String, String[]> eventHandlerConfiguration= new Dictionary<String, String[]>();
-            Func<Type, IDomainEventHandler> createEventHandlerFunc = (t) => {
-                                                                         return new TestDomainEventHandler();
-                                                                     };
 
-            List<String> handlers = new List<String>();
-            handlers.Add("Shared.EventStore.Tests.TestObjects.TestDomainEventHandler, Shared.EventStore.Tests");
-            eventHandlerConfiguration.Add("EstateCreatedEvent", handlers.ToArray());
+            IDomainEventHandler CreateEventHandlerFunc(Type t) {
+                if (t.Name == nameof(TestDomainEventHandler)) return new TestDomainEventHandler();
 
-            DomainEventHandlerResolver r = new DomainEventHandlerResolver(eventHandlerConfiguration, createEventHandlerFunc);
+                if (t.Name == nameof(TestDomainEventHandler2)) return new TestDomainEventHandler2();
+                return null;
+            }
+
+            eventHandlerConfiguration.Add("Shared.EventStore.Tests.TestObjects.TestDomainEventHandler, Shared.EventStore.Tests", new String[]{"EstateCreatedEvent"});
+            eventHandlerConfiguration.Add("Shared.EventStore.Tests.TestObjects.TestDomainEventHandler2, Shared.EventStore.Tests", new String[] { "EstateCreatedEvent" });
+
+            DomainEventHandlerResolver r = new DomainEventHandlerResolver(eventHandlerConfiguration, CreateEventHandlerFunc);
             List<IDomainEventHandler> result  = r.GetDomainEventHandlers(new EstateCreatedEvent(TestData.AggregateId, TestData.EstateName));
-            result.Count.ShouldBe(1);
-            result.Single().ShouldBeOfType(typeof(TestDomainEventHandler));
+            result.Count.ShouldBe(2);
+            result.Count(x => x.GetType() == typeof(TestDomainEventHandler)).ShouldBe(1);
+            result.Count(x => x.GetType() == typeof(TestDomainEventHandler2)).ShouldBe(1);
         }
 
         [Fact]

--- a/Shared.EventStore.Tests/TestObjects/TestDomainEventHandler.cs
+++ b/Shared.EventStore.Tests/TestObjects/TestDomainEventHandler.cs
@@ -18,3 +18,14 @@ public class TestDomainEventHandler : IDomainEventHandler
         return Result.Success();
     }
 }
+
+public class TestDomainEventHandler2 : IDomainEventHandler
+{
+    public List<IDomainEvent> DomainEvents = new();
+
+    public async Task<Result> Handle(IDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        DomainEvents.Add(domainEvent);
+        return Result.Success();
+    }
+}

--- a/Shared.EventStore/EventHandling/DomainEventHandlerResolver.cs
+++ b/Shared.EventStore/EventHandling/DomainEventHandlerResolver.cs
@@ -32,16 +32,8 @@
             this.EventHandlerConfiguration = eventHandlerConfiguration;
 
             this.DomainEventHandlers = new Dictionary<String, IDomainEventHandler>();
-
-            List<String> handlers = new List<String>();
-
-            // Precreate the Event Handlers here
-            foreach (KeyValuePair<String, String[]> handlerConfig in eventHandlerConfiguration)
-            {
-                handlers.AddRange(handlerConfig.Value);
-            }
-
-            IEnumerable<String> distinctHandlers = handlers.Distinct();
+            
+            IEnumerable<String> distinctHandlers = eventHandlerConfiguration.Keys.Select(k => k);
 
             foreach (String handlerTypeString in distinctHandlers)
             {
@@ -72,15 +64,17 @@
             String typeString = domainEvent.GetType().Name;
 
             // Lookup the list
-            Boolean eventIsConfigured = this.EventHandlerConfiguration.ContainsKey(typeString);
-
+            var eventIsConfigured = this.EventHandlerConfiguration.Any(kv => kv.Value.Contains(typeString));
             if (!eventIsConfigured)
             {
                 // No handlers setup, return null and let the caller decide what to do next
                 return null;
             }
 
-            String[] handlers = this.EventHandlerConfiguration[typeString];
+            List<String> handlers = this.EventHandlerConfiguration
+                .Where(kv => kv.Value.Contains(typeString))
+                .Select(kv => kv.Key)
+                .ToList();
 
             List<IDomainEventHandler> handlersToReturn = new List<IDomainEventHandler>();
 


### PR DESCRIPTION
- Updated `DomainEventHandlerResolverTests` to support multiple event handlers, specifically `TestDomainEventHandler` and `TestDomainEventHandler2`, and modified the event handler configuration accordingly.
- Added an asynchronous `Handle` method to `TestDomainEventHandler` and created a new class `TestDomainEventHandler2` with similar functionality.
- Simplified the `DomainEventHandlerResolver` constructor by removing unnecessary list handling and directly using keys from the configuration.
- Improved event configuration checking logic to allow for more flexible matching of event types to handlers.