### PR TITLE
Refactor SubscriptionWorker creation for flexibility

### DIFF
--- a/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
@@ -50,10 +50,11 @@ namespace Shared.EventStore.Tests
             Dictionary<String, IDomainEventHandlerResolver> eventHandlerResolvers = new();
             eventHandlerResolvers.Add("Ordered", deh.Object);
             eventHandlerResolvers.Add("Main", deh.Object);
+            eventHandlerResolvers.Add("Domain", deh.Object);
             Action<TraceEventType, String, String> traceHandler = (et, type, msg)=> { TestOutputHelper.WriteLine(msg); };
             var result = IApplicationBuilderExtenstions.ConfigureSubscriptions(subscriptionRepository.Object, config,
                 eventStoreConnectionString, eventHandlerResolvers, traceHandler);
-            result.Count.ShouldBe(2);
+            result.Count.ShouldBe(3);
         }
 
         [Fact]

--- a/Shared.EventStore/Extensions/IApplicationBuilderExtenstions.cs
+++ b/Shared.EventStore/Extensions/IApplicationBuilderExtenstions.cs
@@ -88,27 +88,27 @@ public static class IApplicationBuilderExtenstions
                 }
             }
             else {
-                KeyValuePair<String, IDomainEventHandlerResolver> ehr = eventHandlerResolvers.SingleOrDefault(e => e.Key == "Main");
-                if (ehr.Value != null) {
-                    for (Int32 i = 0; i < configurationSubscriptionWorker.InstanceCount; i++) {
-                        SubscriptionWorker worker = SubscriptionWorker.CreateSubscriptionWorker(eventStoreConnectionString,
-                                                                                                ehr.Value,
-                                                                                                subscriptionRepository,
-                                                                                                configurationSubscriptionWorker.InflightMessages,
-                                                                                                configuration.PersistentSubscriptionPollingInSeconds);
+                List<KeyValuePair<String, IDomainEventHandlerResolver>> resolvers = eventHandlerResolvers.Where(e => e.Key != "Ordered").ToList();
 
-                        worker.Trace += (_,
-                                         args) => traceHandler(TraceEventType.Information, "MAIN", args.Message);
-                        worker.Warning += (_,
-                                           args) => traceHandler(TraceEventType.Warning, "MAIN", args.Message);
-                        worker.Error += (_,
-                                         args) => traceHandler(TraceEventType.Error, "MAIN", args.Message);
-                        worker.SetIgnoreGroups(configurationSubscriptionWorker.IgnoreGroups);
-                        worker.SetIgnoreStreams(configurationSubscriptionWorker.IgnoreStreams);
-                        worker.SetIncludeGroups(configurationSubscriptionWorker.IncludeGroups);
-                        worker.SetIncludeStreams(configurationSubscriptionWorker.IncludeStreams);
+                foreach (KeyValuePair<String, IDomainEventHandlerResolver> domainEventHandlerResolver in resolvers) {
 
-                        workers.Add(worker);
+                    if (domainEventHandlerResolver.Value != null) {
+                        for (Int32 i = 0; i < configurationSubscriptionWorker.InstanceCount; i++) {
+                            SubscriptionWorker worker = SubscriptionWorker.CreateSubscriptionWorker(eventStoreConnectionString, domainEventHandlerResolver.Value, subscriptionRepository, configurationSubscriptionWorker.InflightMessages, configuration.PersistentSubscriptionPollingInSeconds);
+
+                            worker.Trace += (_,
+                                             args) => traceHandler(TraceEventType.Information, domainEventHandlerResolver.Key.ToUpper(), args.Message);
+                            worker.Warning += (_,
+                                               args) => traceHandler(TraceEventType.Warning, domainEventHandlerResolver.Key.ToUpper(), args.Message);
+                            worker.Error += (_,
+                                             args) => traceHandler(TraceEventType.Error, domainEventHandlerResolver.Key.ToUpper(), args.Message);
+                            worker.SetIgnoreGroups(configurationSubscriptionWorker.IgnoreGroups);
+                            worker.SetIgnoreStreams(configurationSubscriptionWorker.IgnoreStreams);
+                            worker.SetIncludeGroups(configurationSubscriptionWorker.IncludeGroups);
+                            worker.SetIncludeStreams(configurationSubscriptionWorker.IncludeStreams);
+
+                            workers.Add(worker);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Updated the logic to iterate over all `IDomainEventHandlerResolver` instances in `eventHandlerResolvers`, allowing for the creation of multiple `SubscriptionWorker` instances. Enhanced logging by incorporating the resolver key in trace, warning, and error messages to improve context and scalability.