### PR TITLE
Add IsDomainOnly property to SubscriptionWorkerConfig

### DIFF
--- a/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
@@ -42,7 +42,13 @@ namespace Shared.EventStore.Tests
                         Enabled = true,
                         IsOrdered = false,
                         InstanceCount = 1,
+                    },new SubscriptionWorkerConfig
+                    {
+                        Enabled = true,
+                        IsDomainOnly = true,
+                        InstanceCount = 1,
                     }
+
                 }
             };
             Mock<IDomainEventHandlerResolver> deh = new Mock<IDomainEventHandlerResolver>();

--- a/Shared.EventStore/Extensions/SubscriptionWorkerConfig.cs
+++ b/Shared.EventStore/Extensions/SubscriptionWorkerConfig.cs
@@ -23,6 +23,7 @@ public class SubscriptionWorkerConfig
     public Int32 InstanceCount { get; set; }
 
     public Boolean IsOrdered { get; set; }
+    public Boolean IsDomainOnly { get; set; }
 
     public String WorkerName { get; set; }
 


### PR DESCRIPTION
Introduce the IsDomainOnly property to SubscriptionWorkerConfig for domain-specific subscription worker configuration. Update ApplicationBuilderExtensionsTests to create a domain-only worker instance. Modify IApplicationBuilderExtenstions to handle domain-only logic, including creating workers with appropriate event handler resolvers and trace handlers. Remove previous logic for non-domain cases, defaulting to the "Main" resolver when IsDomainOnly is false.