### PR TITLE
Update dependencies and refactor tests and methods

### DIFF
--- a/ClientProxyBase/ClientProxyBase.csproj
+++ b/ClientProxyBase/ClientProxyBase.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SimpleResults" Version="3.0.1" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Driver/Driver.csproj
+++ b/Driver/Driver.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.13" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.EventStore.Tests/AggregateRepositoryTests.cs
+++ b/Shared.EventStore.Tests/AggregateRepositoryTests.cs
@@ -113,7 +113,7 @@ public class AggregateRepositoryTests{
         AggregateRepository<TestAggregate, DomainEvent> testAggregateRepository = new AggregateRepository<TestAggregate, DomainEvent>(context.Object, factory);
         Result<TestAggregate> testAggregate = await testAggregateRepository.GetLatestVersionFromLastEvent(TestData.AggregateId, CancellationToken.None);
 
-        Result result = await testAggregateRepository.SaveChanges(testAggregate, CancellationToken.None);
+        Result result = await testAggregateRepository.SaveChanges(testAggregate.Data, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();
     }
 
@@ -134,7 +134,7 @@ public class AggregateRepositoryTests{
         AggregateRepository<TestAggregate, DomainEvent> testAggregateRepository = new AggregateRepository<TestAggregate, DomainEvent>(context.Object, factory);
         Result<TestAggregate> testAggregate = await testAggregateRepository.GetLatestVersionFromLastEvent(TestData.AggregateId, CancellationToken.None);
         testAggregate.Data.SetAggregateName("New name", Guid.NewGuid());
-        Result result = await testAggregateRepository.SaveChanges(testAggregate, CancellationToken.None);
+        Result result = await testAggregateRepository.SaveChanges(testAggregate.Data, CancellationToken.None);
         result.IsFailed.ShouldBeTrue();
     }
 
@@ -172,7 +172,8 @@ public class AggregateRepositoryTests{
         context.Setup(c => c.GetEventsBackward(It.IsAny<String>(), It.IsAny<Int32>(), It.IsAny<CancellationToken>())).ReturnsAsync(e);
 
         AggregateRepository<TestAggregate, DomainEvent> testAggregateRepository = new AggregateRepository<TestAggregate, DomainEvent>(context.Object, factory);
-        TestAggregate testAggregate = await testAggregateRepository.GetLatestVersionFromLastEvent(TestData.AggregateId, CancellationToken.None);
+        Result<TestAggregate> testAggregaterResult = await testAggregateRepository.GetLatestVersionFromLastEvent(TestData.AggregateId, CancellationToken.None);
+        var testAggregate = testAggregaterResult.Data;
         testAggregate.SetAggregateName("New name", Guid.NewGuid());
         Result result = await testAggregateRepository.SaveChanges(testAggregate, CancellationToken.None);
         result.IsSuccess.ShouldBeTrue();

--- a/Shared.EventStore.Tests/Shared.EventStore.Tests.csproj
+++ b/Shared.EventStore.Tests/Shared.EventStore.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Pose" Version="1.2.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Shared.EventStore/Shared.EventStore.csproj
+++ b/Shared.EventStore/Shared.EventStore.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.13" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
-		<PackageReference Include="SimpleResults" Version="3.0.1" />
+		<PackageReference Include="SimpleResults" Version="4.0.0" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 

--- a/Shared.EventStoreContext.Tests/EventStoreContextTests.cs
+++ b/Shared.EventStoreContext.Tests/EventStoreContextTests.cs
@@ -295,7 +295,7 @@ namespace Shared.EventStore.Tests{
             var definition = new{
                                     estates = new List<String>()
                                 };
-            var result = JsonConvert.DeserializeAnonymousType(queryResult, definition);
+            var result = JsonConvert.DeserializeAnonymousType(queryResult.Data, definition);
 
             result.estates.Contains(event1.EstateName).ShouldBeTrue();
             result.estates.Contains(event2.EstateName).ShouldBeTrue();

--- a/Shared.EventStoreContext.Tests/Shared.EventStoreContext.Tests.csproj
+++ b/Shared.EventStoreContext.Tests/Shared.EventStoreContext.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/Shared.IntegrationTesting.Tests/Shared.IntegrationTesting.Tests.csproj
+++ b/Shared.IntegrationTesting.Tests/Shared.IntegrationTesting.Tests.csproj
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.IntegrationTesting.UnitTests/Shared.IntegrationTesting.UnitTests.csproj
+++ b/Shared.IntegrationTesting.UnitTests/Shared.IntegrationTesting.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.13" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Shared.IntegrationTesting/Shared.IntegrationTesting.csproj
+++ b/Shared.IntegrationTesting/Shared.IntegrationTesting.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="EventStore.Client.Grpc.PersistentSubscriptions" Version="23.3.8" />
     <PackageReference Include="EventStore.Client.Grpc.ProjectionManagement" Version="23.3.8" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.Results.Web/Shared.Results.Web.csproj
+++ b/Shared.Results.Web/Shared.Results.Web.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleResults" Version="3.0.1" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Shared.Results/Shared.Results.csproj
+++ b/Shared.Results/Shared.Results.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleResults" Version="3.0.1" />
+    <PackageReference Include="SimpleResults" Version="4.0.0" />
       </ItemGroup>
 
 </Project>

--- a/Shared.Tests/Shared.Tests.csproj
+++ b/Shared.Tests/Shared.Tests.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+		<PackageReference Include="SimpleResults" Version="4.0.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.13" />
-	  <PackageReference Include="SimpleResults" Version="3.0.1" />
+	  <PackageReference Include="SimpleResults" Version="4.0.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />


### PR DESCRIPTION
- Bump `SimpleResults` package version to `4.0.0` across multiple projects.
- Modify `AggregateRepositoryTests` to use `testAggregate.Data` in `SaveChanges`.
- Refactor `DoHealthCheck` method in `BaseDockerHelper` for improved readability and error handling.
- Correct deserialization in `EventStoreContextTests` to reference `queryResult.Data`.
- Upgrade `NUnit.Analyzers` from `4.6.0` to `4.7.0` in `Shared.IntegrationTesting.csproj`.