### PR TITLE
Enhance retry logic in PolicyFactory and add tests

### DIFF
--- a/Shared.Tests/Shared.Tests.csproj
+++ b/Shared.Tests/Shared.Tests.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<DebugType>None</DebugType>
+		<DebugType>Full</DebugType>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 


### PR DESCRIPTION
Updated CreatePolicy to support custom exception-based retry logic. Added ShouldRetryException method and modified CreateRetryPolicy accordingly. Introduced new tests in PolicyFactoryTests to validate behavior with and without retries. Updated project settings for full debugging information.

Fixes #327 