### PR TITLE
Refactor RegisterHttpClient to use generic type parameter

### DIFF
--- a/ClientProxyBase/ServiceCollectionExtensions.cs
+++ b/ClientProxyBase/ServiceCollectionExtensions.cs
@@ -4,8 +4,8 @@ namespace ClientProxyBase;
 
 public static class ServiceCollectionExtensions
 {
-    public static IHttpClientBuilder RegisterHttpClient(this IServiceCollection services, string name = "") {
-        return services.AddHttpClient(name).AddHttpMessageHandler<CorrelationIdHandler>()
+    public static IHttpClientBuilder RegisterHttpClient<T>(this IServiceCollection services) where T : class {
+        return services.AddHttpClient<T>().AddHttpMessageHandler<CorrelationIdHandler>()
             .ConfigurePrimaryHttpMessageHandler(GetSocketsHttpHandler.GetHandler);
     }
 }


### PR DESCRIPTION
Updated the `RegisterHttpClient` method to accept a generic type parameter `T`, removing the previous string-based overload. This change allows for the registration of an `HttpClient` using a specified class type while configuring the primary HTTP message handler with `GetSocketsHttpHandler.GetHandler` and retaining the addition of the `CorrelationIdHandler`.