### PR TITLE
Add correlation ID to context for HttpClient access

### DIFF
--- a/Shared/Middleware/CorrelationIdMiddleware.cs
+++ b/Shared/Middleware/CorrelationIdMiddleware.cs
@@ -50,6 +50,7 @@ namespace Shared.Middleware
             if (correlationId != Guid.Empty)
             {
                 tenantContext.SetCorrelationId(correlationId);
+                context.Items[KeyNameCorrelationId] = correlationId.ToString(); // make it accessible to HttpClient handlers
             }
 
             tenantContext.Initialise(tenantIdentifiers, logPerTenantEnabled);


### PR DESCRIPTION
This change stores the parsed `correlationId` as a string in the `context.Items` dictionary. This enhancement allows the middleware to share the correlation ID across different components of the application, improving traceability and context management.

closes #355 