### PR TITLE
Add ConfigurationHost and EstateManagementUI Docker support

### DIFF
--- a/Shared.IntegrationTesting.Tests/GenericSteps.cs
+++ b/Shared.IntegrationTesting.Tests/GenericSteps.cs
@@ -40,17 +40,13 @@ public class GenericSteps
 
         this.TestingContext.DockerHelper = new TestDockerHelper();
         this.TestingContext.DockerHelper.Logger = logger;
-        //this.TestingContext.DockerHelper.SqlServerContainer = Setup.DatabaseServerContainer;
-        //this.TestingContext.DockerHelper.SqlServerNetwork = Setup.DatabaseServerNetwork;
-        //this.TestingContext.DockerHelper.DockerCredentials = Setup.DockerCredentials;
-        //this.TestingContext.DockerHelper.SqlCredentials = Setup.SqlCredentials;
-        //this.TestingContext.DockerHelper.SqlServerContainerName = "sharedsqlserver";
 
         DockerServices services = DockerServices.SqlServer | DockerServices.EventStore | DockerServices.MessagingService | DockerServices.SecurityService |
                                   DockerServices.CallbackHandler | DockerServices.FileProcessor |
                                   DockerServices.TestHost | DockerServices.TransactionProcessor |
-                                  DockerServices.TransactionProcessorAcl;
-        
+                                  DockerServices.TransactionProcessorAcl | DockerServices.ConfigurationHost
+                                  | DockerServices.EstateManagementUI;
+
         this.TestingContext.Logger = logger;
         this.TestingContext.Logger.LogInformation("About to Start Containers for Scenario Run");
         this.TestingContext.DockerHelper.ScenarioName = scenarioName;

--- a/Shared.IntegrationTesting/ContainerType.cs
+++ b/Shared.IntegrationTesting/ContainerType.cs
@@ -13,6 +13,8 @@ public enum ContainerType
     TransactionProcessor,
     FileProcessor,
     TransactionProcessorAcl,
+    ConfigurationHost,
+    EstateManangementUI,
     NotSet
 }
 
@@ -28,7 +30,9 @@ public enum DockerServices
     TestHost = 32,
     TransactionProcessor = 64,
     FileProcessor = 128,
-    TransactionProcessorAcl = 256
+    TransactionProcessorAcl = 256,
+    ConfigurationHost = 512,
+    EstateManagementUI = 1024,
 }
 
 public enum DockerEnginePlatform

--- a/Shared.IntegrationTesting/DockerPorts.cs
+++ b/Shared.IntegrationTesting/DockerPorts.cs
@@ -21,4 +21,7 @@ public static class DockerPorts
     public static readonly Int32 TransactionProcessorAclDockerPort = 5003;
 
     public static readonly Int32 TransactionProcessorDockerPort = 5002;
+    public static readonly Int32 ConfigHostDockerPort = 9200;
+
+    public static readonly Int32 EstateManagementUIDockerPort = 5004;
 }

--- a/Shared.IntegrationTesting/TestContainers/BaseDockerHelper.cs
+++ b/Shared.IntegrationTesting/TestContainers/BaseDockerHelper.cs
@@ -202,6 +202,7 @@ public abstract class BaseDockerHelper{
             {"AppSettings:ClientSecret", this.ClientDetails.clientSecret},
             {"AppSettings:MessagingServiceApi", $"http://{this.MessagingServiceContainerName}:{DockerPorts.MessagingServiceDockerPort}"},
             {"AppSettings:TransactionProcessorApi", $"http://{this.TransactionProcessorContainerName}:{DockerPorts.TransactionProcessorDockerPort}"},
+            {"AppSettings:FileProcessorApi", $"http://{this.FileProcessorContainerName}:{DockerPorts.FileProcessorDockerPort}"},
             {"ConnectionStrings:HealthCheck", this.SetConnectionString("master", this.UseSecureSqlServerDatabase)},
             {"\"EventStoreSettings:Insecure", this.IsSecureEventStore.ToString()}
             

--- a/Shared.IntegrationTesting/TestContainers/BaseDockerHelper.cs
+++ b/Shared.IntegrationTesting/TestContainers/BaseDockerHelper.cs
@@ -62,6 +62,8 @@ public abstract class BaseDockerHelper{
 
     protected String EventStoreContainerName;
 
+    public String ConfigHostContainerName;
+    public Int32 ConfigHostPort;
     protected Int32 EventStoreHttpPort;
     protected Int32 EventStoreSecureHttpPort;
 
@@ -123,7 +125,7 @@ public abstract class BaseDockerHelper{
                                                                                                                                                                                           errors) => true
                                                                                                                                                }
                                                                                             }));
-
+        
         // Setup the default image details
         this.DockerPlatform = BaseDockerHelper.GetDockerEnginePlatform().Result.Data;
         if (this.DockerPlatform == DockerEnginePlatform.Windows)
@@ -137,6 +139,8 @@ public abstract class BaseDockerHelper{
             this.ImageDetails.Add(ContainerType.TransactionProcessor, ("stuartferguson/transactionprocessorwindows:master", true));
             this.ImageDetails.Add(ContainerType.FileProcessor, ("stuartferguson/fileprocessorwindows:master", true));
             this.ImageDetails.Add(ContainerType.TransactionProcessorAcl, ("stuartferguson/transactionprocessoraclwindows:master", true));
+            this.ImageDetails.Add(ContainerType.ConfigurationHost, ("stuartferguson/mobileconfigurationwindows:master", true));
+            //this.ImageDetails.Add(ContainerType.EstateManangementUI, ("stuartferguson/estatemanagementuiwindows:master", true));
         }
         else
         {
@@ -149,6 +153,8 @@ public abstract class BaseDockerHelper{
             this.ImageDetails.Add(ContainerType.TransactionProcessor, ("stuartferguson/transactionprocessor:master", true));
             this.ImageDetails.Add(ContainerType.FileProcessor, ("stuartferguson/fileprocessor:master", true));
             this.ImageDetails.Add(ContainerType.TransactionProcessorAcl, ("stuartferguson/transactionprocessoracl:master", true));
+            this.ImageDetails.Add(ContainerType.ConfigurationHost, ("stuartferguson/mobileconfiguration:master", true));
+            this.ImageDetails.Add(ContainerType.EstateManangementUI, ("stuartferguson/estatemanagementui:latest", true));
         }
 
         this.HostPorts = new Dictionary<ContainerType, Int32>();
@@ -297,8 +303,14 @@ public abstract class BaseDockerHelper{
         this.MessagingServiceContainerName = $"messaging{this.TestId:N}";
         this.TransactionProcessorContainerName = $"transaction{this.TestId:N}";
         this.TransactionProcessorAclContainerName = $"transactionacl{this.TestId:N}";
+        this.ConfigHostContainerName = $"mobileconfighost{this.TestId:N}";
+        this.EstateManagementUiContainerName = $"estateadministrationui{this.TestId:N}";
     }
-    
+
+    public Int32 EstateManagementUiPort;
+
+    protected String EstateManagementUiContainerName;
+
     public virtual ContainerBuilder SetupEventStoreContainer(){
         this.Trace($"About to Start Event Store Container [{this.DockerPlatform}]");
 
@@ -425,6 +437,60 @@ public abstract class BaseDockerHelper{
         //String containerFolder = this.DockerPlatform == DockerEnginePlatform.Windows ? "C:\\home\\txnproc\\bulkfiles" : "/home/txnproc/bulkfiles";
         //fileProcessorContainer.Mount(uploadFolder, containerFolder, MountType.ReadWrite);
         return fileProcessorContainer;
+    }
+
+    protected virtual ContainerBuilder SetupEstateManagementUiContainer()
+    {
+        Trace("About to Start Estate Management UI Container");
+
+        Dictionary<String, String> environmentVariables = this.GetCommonEnvironmentVariables();
+
+        environmentVariables.Remove("AppSettings:ClientId");
+        environmentVariables.Remove("AppSettings:ClientSecret");
+
+        environmentVariables.Add("AppSettings:Authority", $"https://{this.SecurityServiceContainerName}:0");  // The port is set to 0 to stop defaulting to 443
+        environmentVariables.Add("AppSettings:SecurityServiceLocalPort", $"{DockerPorts.SecurityServiceDockerPort}");
+        environmentVariables.Add("AppSettings:SecurityServicePort", $"{this.SecurityServicePort}");
+        environmentVariables.Add("AppSettings:HttpClientIgnoreCertificateErrors", $"true");
+        //environmentVariables.Add($"AppSettings:PermissionsBypass=true");
+        environmentVariables.Add("AppSettings:IsIntegrationTest", "true");
+        environmentVariables.Add("ASPNETCORE_ENVIRONMENT", "Development");
+        environmentVariables.Add("EstateManagementScope", "estateManagement");
+        environmentVariables.Add("urls", "https://*:5004");
+        environmentVariables.Add($"AppSettings:ClientId", "estateUIClient");
+        environmentVariables.Add($"AppSettings:ClientSecret", "Secret1");
+        environmentVariables.Add($"AppSettings:BackEndClientId", "serviceClient");
+        environmentVariables.Add($"AppSettings:BackEndClientSecret", "Secret1");
+        environmentVariables.Add($"DataReloadConfig:DefaultInSeconds", "1");
+        environmentVariables.Add("ConnectionStrings:TransactionProcessorReadModel", this.SetConnectionString("TransactionProcessorReadModel", this.UseSecureSqlServerDatabase));
+
+        (String imageName, Boolean useLatest) imageDetails = this.GetImageDetails(ContainerType.EstateManangementUI).Data;
+
+        ContainerBuilder containerBuilder = new ContainerBuilder()
+            .WithName(this.EstateManagementUiContainerName)
+            .WithImage(imageDetails.imageName)
+            .WithEnvironment(environmentVariables)
+            .MountHostFolder(this.DockerPlatform, this.HostTraceFolder)
+            .WithPortBinding(DockerPorts.EstateManagementUIDockerPort,true);
+
+        return containerBuilder;
+    }
+
+    public virtual ContainerBuilder SetupConfigHostContainer()
+    {
+        this.Trace("About to Start Config Host Container");
+        Dictionary<String, String> environmentVariables = new();
+        environmentVariables.Add("AppSettings:InMemoryDatabase", "true");
+
+        (String imageName, Boolean useLatest) imageDetails = this.GetImageDetails(ContainerType.ConfigurationHost).Data;
+
+        ContainerBuilder configHostContainer = new ContainerBuilder().WithName(this.ConfigHostContainerName)
+            .WithImage(imageDetails.imageName)
+            .WithEnvironment(environmentVariables)
+            .MountHostFolder(this.DockerPlatform, this.HostTraceFolder)
+            .WithPortBinding(DockerPorts.ConfigHostDockerPort, true);
+
+        return configHostContainer;
     }
 
     public virtual ContainerBuilder SetupMessagingServiceContainer(){
@@ -766,6 +832,8 @@ public abstract class BaseDockerHelper{
             ContainerType.TransactionProcessor => ("http", this.TransactionProcessorPort),
             ContainerType.SecurityService => ("https", this.SecurityServicePort),
             ContainerType.TransactionProcessorAcl => ("http", this.TransactionProcessorAclPort),
+            //ContainerType.ConfigurationHost => ("http", this.ConfigHostPort),
+            ContainerType.EstateManangementUI => ("https", this.EstateManagementUiPort),
             _ => (null, 0)
         };
 
@@ -887,6 +955,7 @@ public abstract class BaseDockerHelper{
         return connectionString;
     }
 
+    
     protected async Task<IContainer> StartContainer2(Func<ContainerBuilder> buildContainerFunc, List<INetwork> networkServices, DockerServices dockerService){
         if ((this.RequiredDockerServices & dockerService) != dockerService)
         {
@@ -917,6 +986,8 @@ public abstract class BaseDockerHelper{
                 DockerServices.TransactionProcessorAcl => ContainerType.TransactionProcessorAcl,
                 DockerServices.EventStore=> ContainerType.EventStore,
                 DockerServices.SqlServer => ContainerType.SqlServer,
+                DockerServices.ConfigurationHost => ContainerType.ConfigurationHost,
+                DockerServices.EstateManagementUI => ContainerType.EstateManangementUI,
                 _ => ContainerType.NotSet
             };
 
@@ -992,6 +1063,12 @@ public abstract class BaseDockerHelper{
                 break;
             case ContainerType.TransactionProcessorAcl: 
                 TransactionProcessorAclPort = GetPort(DockerPorts.TransactionProcessorAclDockerPort); 
+                break;
+            case ContainerType.ConfigurationHost:
+                ConfigHostPort = GetPort(DockerPorts.ConfigHostDockerPort);
+                break;
+            case ContainerType.EstateManangementUI:
+                EstateManagementUiPort = GetPort(DockerPorts.EstateManagementUIDockerPort);
                 break;
         }
     }

--- a/Shared.IntegrationTesting/TestContainers/DockerHelper.cs
+++ b/Shared.IntegrationTesting/TestContainers/DockerHelper.cs
@@ -85,10 +85,8 @@ public abstract class DockerHelper : BaseDockerHelper
         INetwork testNetwork = await this.SetupTestNetwork();
         this.TestNetworks.Add(testNetwork);
 
-        //INetwork testNetwork2 = await this.SetupTestNetwork($"testnw{Guid.NewGuid():N}");
         List<INetwork> networks = [
             testNetwork,
-            //testNetwork2
         ];
 
         await StartContainer2(this.ConfigureSqlContainer, networks, DockerServices.SqlServer);
@@ -102,6 +100,9 @@ public abstract class DockerHelper : BaseDockerHelper
         await StartContainer2(this.SetupTransactionProcessorContainer, networks, DockerServices.TransactionProcessor);
         await StartContainer2(this.SetupFileProcessorContainer, networks, DockerServices.FileProcessor);
         await StartContainer2(this.SetupTransactionProcessorAclContainer, networks, DockerServices.TransactionProcessorAcl);
+        await StartContainer2(this.SetupConfigHostContainer, networks, DockerServices.ConfigurationHost);
+        if (this.DockerPlatform == DockerEnginePlatform.Linux)
+            await StartContainer2(this.SetupEstateManagementUiContainer, networks, DockerServices.EstateManagementUI);
 
         await this.LoadEventStoreProjections();
         


### PR DESCRIPTION
Extend test infrastructure to support ConfigurationHost and EstateManagementUI containers. Update enums, port definitions, and container setup logic to include these services. Add container configuration methods and ensure proper startup and port management for integration testing.

closes #1220 