### PR TITLE
Handle enum types in ConfigurationReader value parsing

### DIFF
--- a/Shared/General/ConfigurationReader.cs
+++ b/Shared/General/ConfigurationReader.cs
@@ -86,6 +86,10 @@ public static class ConfigurationReader
                 return defaultValue;
             }
 
+            if (typeof(T).IsEnum) {
+                return (T)Enum.Parse(typeof(T), value, ignoreCase: true);
+            }
+
             return (T)Convert.ChangeType(value, typeof(T));
         }
         catch (KeyNotFoundException)


### PR DESCRIPTION
Updated ConfigurationReader to support parsing enum values from configuration strings using Enum.Parse with case-insensitive matching. This ensures correct conversion for enum types, which are not handled by Convert.ChangeType.

closes #1234