### PR TITLE
Update CI workflows: remove tests, fix artifact paths

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -35,13 +35,6 @@ jobs:
       run: |
         sudo cp ./Shared.EventStoreContext.Tests/certs/ca/ca.crt /usr/local/share/ca-certificates/ca.crt
         sudo update-ca-certificates
-
-    - name: Run Unit Tests
-      run: |
-        echo "ASPNETCORE_ENVIRONMENT are > ${ASPNETCORE_ENVIRONMENT}"
-        dotnet test "Shared.Tests\Shared.Tests.csproj"
-        dotnet test "Shared.EventStore.Tests\Shared.EventStore.Tests.csproj"
-        dotnet test "Shared.EventStoreContext.Tests\Shared.EventStoreContext.Tests.csproj"
         
     - name: Build Nuget Packages
       run: |

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -76,7 +76,6 @@ jobs:
         dotnet test "Shared.IntegrationTesting.Tests\Shared.IntegrationTesting.Tests.csproj"
 
     - uses: actions/upload-artifact@v4.4.3
-      if: ${{ failure() }}
       with:
         name: tracelogslinux
-        path: /home/txnproc/trace/   
+        path: /home/runner/trace/   

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -49,10 +49,9 @@ jobs:
         dotnet test "Shared.IntegrationTesting.Tests\Shared.IntegrationTesting.Tests.csproj"
 
     - uses: actions/upload-artifact@v4.4.3
-      #if: ${{ failure() }}
       with:
         name: tracelogslinux
-        path: /home/txnproc/trace/   
+        path: /home/runner/trace/   
 
   buildwindows:
     name: "Build and Test Pull Requests - Windows"
@@ -99,7 +98,6 @@ jobs:
         dotnet test "Shared.IntegrationTesting.Tests\Shared.IntegrationTesting.Tests.csproj"
 
     - uses: actions/upload-artifact@v4.4.3
-      #if: ${{ failure() }}
       with:
         name: tracelogswindows
         path: C:\\Users\\runneradmin\\txnproc


### PR DESCRIPTION
Removed unit test steps from createrelease.yml, retaining only build and NuGet packaging. Updated Linux trace log artifact paths from /home/txnproc/trace/ to /home/runner/trace/ in nightlybuild.yml and pullrequest.yml. Cleaned up commented-out conditional in pullrequest.yml. Windows artifact upload remains unchanged.

closes #1249 