### PR TITLE
Add System.Text.Json support with custom serialization

### DIFF
--- a/ClientProxyBase/ClientProxyBase.cs
+++ b/ClientProxyBase/ClientProxyBase.cs
@@ -8,6 +8,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +25,39 @@ public abstract partial class ClientProxyBase {
         this.Serialise = Serialise;
         this.Deserialise = Deserialise;
     }
+
+    // This ctor will be removed once all the client proxies have been updated to use the new ctor above. It is kept for backwards compatibility.
+    protected ClientProxyBase(HttpClient httpClient) {
+        this.HttpClient = httpClient;
+
+        JsonSerializerOptions JsonSerializerOptions = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            WriteIndented = true,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver
+            {
+                Modifiers =
+                {
+                    typeInfo =>
+                    {
+                        String[] names = new[] { "AggregateId", "AggregateVersion", "EventId", "EventNumber", "EventTimestamp", "EventType" };
+                        List<JsonPropertyInfo> matches = typeInfo.Properties
+                            .Where(p => names.Any(n => string.Equals(p.Name, n, StringComparison.OrdinalIgnoreCase)))
+                            .ToList();
+
+                        foreach (JsonPropertyInfo match in matches) {
+                            match.ShouldSerialize = (_, _) => false;
+                        }
+                    }
+                }
+            }
+        };
+
+        this.Serialise = (obj) => System.Text.Json.JsonSerializer.Serialize(obj, JsonSerializerOptions);
+        this.Deserialise = (json, type) => System.Text.Json.JsonSerializer.Deserialize(json, type, JsonSerializerOptions);
+    }
+
 
     #region Methods
 

--- a/ClientProxyBase/ClientProxyBase.csproj
+++ b/ClientProxyBase/ClientProxyBase.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared/Serialisation/StringSerialiser.cs
+++ b/Shared/Serialisation/StringSerialiser.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
@@ -32,6 +34,30 @@ public interface IStringSerialiser {
 public class SystemTextJsonSerializer : IStringSerialiser
 {
     private readonly JsonSerializerOptions Options;
+
+    public static JsonSerializerOptions GetDefaultJsonSerializerOptions() => new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers =
+            {
+                typeInfo =>
+                {
+                    String[] names = new[] { "AggregateId", "AggregateVersion", "EventId", "EventNumber", "EventTimestamp", "EventType" };
+                    List<JsonPropertyInfo> matches = typeInfo.Properties
+                        .Where(p => names.Any(n => string.Equals(p.Name, n, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+
+                    foreach (JsonPropertyInfo match in matches) {
+                        match.ShouldSerialize = (_, _) => false;
+                    }
+                }
+            }
+        }
+    };
 
     public SystemTextJsonSerializer(JsonSerializerOptions options) {
         Options = options;


### PR DESCRIPTION
Added System.Text.Json as a dependency and introduced a new constructor in ClientProxyBase to configure serialization options, including snake_case naming and exclusion of specific properties. Provided a static method for default options in SystemTextJsonSerializer. Updated usings to support these changes for consistent JSON handling.