### PR TITLE
Add JsonSerializerConfiguration for Minimal API setup

### DIFF
--- a/Shared/Serialisation/JsonSerializerConfiguration.cs
+++ b/Shared/Serialisation/JsonSerializerConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json;
+
+namespace Shared.Serialisation;
+
+public static class JsonSerializerConfiguration
+{
+    public static void ConfigureMinimalApi(JsonSerializerOptions serializerOptions)
+    {
+        JsonSerializerOptions defaultOptions = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions();
+        serializerOptions.PropertyNamingPolicy = defaultOptions.PropertyNamingPolicy;
+        serializerOptions.DictionaryKeyPolicy = defaultOptions.DictionaryKeyPolicy;
+        serializerOptions.ReferenceHandler = defaultOptions.ReferenceHandler;
+        serializerOptions.WriteIndented = defaultOptions.WriteIndented;
+        serializerOptions.Converters.Add(new DateTimeSpaceConverter());
+    }
+}


### PR DESCRIPTION
Introduced a static class to configure JsonSerializerOptions for Minimal APIs by copying default settings and adding DateTimeSpaceConverter.

closes #1269 