### PR TITLE
Centralize NuGet package version management

### DIFF
--- a/ClientProxyBase/ClientProxyBase.csproj
+++ b/ClientProxyBase/ClientProxyBase.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="SimpleResults" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,43 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="SimpleResults" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="Polly" Version="8.7.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="EventStore.Client.Grpc.PersistentSubscriptions" Version="23.3.9" />
+    <PackageVersion Include="EventStore.Client.Grpc.ProjectionManagement" Version="23.3.9" />
+    <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="KurrentDB.Client" Version="1.4.0" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="Pose" Version="1.2.1" />
+  </ItemGroup>
+</Project>

--- a/Driver/Driver.csproj
+++ b/Driver/Driver.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="SimpleResults" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/Shared.EventStore.Tests/ApplicationBuilderExtensionsTests.cs
@@ -11,7 +11,7 @@ using Shared.EventStore.Extensions;
 using Shared.EventStore.SubscriptionWorker;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
+//using Xunit.Abstractions;
 
 namespace Shared.EventStore.Tests;
 

--- a/Shared.EventStore.Tests/Shared.EventStore.Tests.csproj
+++ b/Shared.EventStore.Tests/Shared.EventStore.Tests.csproj
@@ -12,20 +12,20 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	  <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+      <PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Pose" Version="1.2.1" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Pose" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="SimpleResults" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Shared.EventStore/Shared.EventStore.csproj
+++ b/Shared.EventStore/Shared.EventStore.csproj
@@ -6,15 +6,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-		<PackageReference Include="KurrentDB.Client" Version="1.4.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-		<PackageReference Include="NLog.Extensions.Logging" Version="6.1.3" />
-		<PackageReference Include="SimpleResults" Version="4.0.0" />
+		<PackageReference Include="AspNetCore.HealthChecks.Uris" />
+		<PackageReference Include="KurrentDB.Client" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+		<PackageReference Include="NLog.Extensions.Logging" />
+		<PackageReference Include="SimpleResults" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="prometheus-net" Version="8.2.1" />
+		<PackageReference Include="prometheus-net" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Shared.EventStoreContext.Tests/Shared.EventStoreContext.Tests.csproj
+++ b/Shared.EventStoreContext.Tests/Shared.EventStoreContext.Tests.csproj
@@ -10,21 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+	<PackageReference Include="AspNetCore.HealthChecks.Uris" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	<PackageReference Include="NUnit" />
+	<PackageReference Include="NUnit3TestAdapter" />
+	<PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+	<PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+	<PackageReference Include="SimpleResults" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/Shared.IntegrationTesting.Tests/Shared.IntegrationTesting.Tests.csproj
+++ b/Shared.IntegrationTesting.Tests/Shared.IntegrationTesting.Tests.csproj
@@ -10,21 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Reqnroll" Version="3.3.4" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.4" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="SimpleResults" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.IntegrationTesting.UnitTests/Shared.IntegrationTesting.UnitTests.csproj
+++ b/Shared.IntegrationTesting.UnitTests/Shared.IntegrationTesting.UnitTests.csproj
@@ -10,18 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="SimpleResults" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Shared.IntegrationTesting/Shared.IntegrationTesting.csproj
+++ b/Shared.IntegrationTesting/Shared.IntegrationTesting.csproj
@@ -6,18 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Reqnroll" Version="3.3.4" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="EventStore.Client.Grpc.PersistentSubscriptions" Version="23.3.9" />
-    <PackageReference Include="EventStore.Client.Grpc.ProjectionManagement" Version="23.3.9" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="Testcontainers" Version="4.12.0" />
-    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="EventStore.Client.Grpc.PersistentSubscriptions" />
+    <PackageReference Include="EventStore.Client.Grpc.ProjectionManagement" />
+    <PackageReference Include="SimpleResults" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Docker.DotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared.Logger/Shared.Logger.csproj
+++ b/Shared.Logger/Shared.Logger.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-		<PackageReference Include="NLog" Version="6.1.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="NLog" />
 	</ItemGroup>
 </Project>

--- a/Shared.Results.Web/Shared.Results.Web.csproj
+++ b/Shared.Results.Web/Shared.Results.Web.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="SimpleResults" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Shared.Results/Shared.Results.csproj
+++ b/Shared.Results/Shared.Results.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="SimpleResults" />
+    <PackageReference Include="Polly" />
   </ItemGroup>
 
 </Project>

--- a/Shared.Tests/ConfigurationReaderTests.cs
+++ b/Shared.Tests/ConfigurationReaderTests.cs
@@ -11,7 +11,6 @@ using General;
 using Microsoft.Extensions.Configuration;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 public partial class SharedTests
 {

--- a/Shared.Tests/Shared.Tests.csproj
+++ b/Shared.Tests/Shared.Tests.csproj
@@ -7,25 +7,25 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
+		<PackageReference Include="AspNetCore.HealthChecks.Uris" />
+		<PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-		<PackageReference Include="SimpleResults" Version="4.0.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="RichardSzalay.MockHttp" />
+		<PackageReference Include="SimpleResults" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Shouldly" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Shared.sln
+++ b/Shared.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11205.157 d18.0
+VisualStudioVersion = 18.0.11205.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "Shared\Shared.csproj", "{FF85F59D-BE70-438E-9A69-5CE7E50B2E0E}"
 EndProject
@@ -25,13 +25,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.EventStore.Tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.IntegrationTesting.Tests", "Shared.IntegrationTesting.Tests\Shared.IntegrationTesting.Tests.csproj", "{77D4A6AC-1DEF-4F6D-88C8-35763A1FD9B5}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2F43E6CC-A4C5-4C18-8674-FF5E2E6C1604}"
-	ProjectSection(SolutionItems) = preProject
-		.github\workflows\createrelease.yml = .github\workflows\createrelease.yml
-		nightlybuild.yml = nightlybuild.yml
-		.github\workflows\pullrequest.yml = .github\workflows\pullrequest.yml
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.EventStoreContext.Tests", "Shared.EventStoreContext.Tests\Shared.EventStoreContext.Tests.csproj", "{A7909DC1-12F9-42F8-B665-E8A2C63B1481}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.IntegrationTesting.UnitTests", "Shared.IntegrationTesting.UnitTests\Shared.IntegrationTesting.UnitTests.csproj", "{5E23CBBB-8484-4F7F-81D9-308957783695}"
@@ -41,6 +34,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.Results.Web", "Shared.Results.Web\Shared.Results.Web.csproj", "{5A8811D2-46B8-4E92-E6DF-B482185EA211}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.Logger", "Shared.Logger\Shared.Logger.csproj", "{9A7AF486-C3B6-463D-812E-DD6D5517C7F3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AAF925EC-8E2D-40EA-BA77-87B097A949D8}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -11,17 +11,17 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-	  <PackageReference Include="SimpleResults" Version="4.0.0" />
-    <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+        <PackageReference Include="SimpleResults" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moved all NuGet package versioning to Directory.Packages.props for central management. Removed explicit Version attributes from .csproj files and updated all project references accordingly. Updated Shared.sln Solution Items to include Directory.Packages.props. Minor code cleanups included.

closes #1279 