### PR TITLE
Reusable SQL Server EF extension for retry configuration

### DIFF
--- a/Shared.Tests/SqlServerDbContextOptionsBuilderExtensionsTests.cs
+++ b/Shared.Tests/SqlServerDbContextOptionsBuilderExtensionsTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.SqlServer;
+using Shared.EntityFramework;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Shared.Tests;
+
+public class SqlServerDbContextOptionsBuilderExtensionsTests
+{
+    [Fact]
+    public void UseSharedSqlServer_UsesDefaultRetryValuesAndMigrationsAssembly()
+    {
+        DbContextOptionsBuilder<TestDbContext> optionsBuilder = new();
+
+        optionsBuilder.UseSharedSqlServer<TestDbContext>("Server=.;Database=DefaultDb;Trusted_Connection=True;");
+
+        using TestDbContext context = new(optionsBuilder.Options);
+
+        var executionStrategy = context.Database.CreateExecutionStrategy();
+        executionStrategy.RetriesOnFailure.ShouldBeFalse();
+
+        object relationalExtension = optionsBuilder.Options.Extensions.Single(extension =>
+            extension.GetType().FullName == "Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal.SqlServerOptionsExtension");
+
+        PropertyInfo migrationsAssemblyProperty = relationalExtension.GetType().GetProperty(
+            "MigrationsAssembly",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Expected a migrations assembly property.");
+
+        string? migrationsAssembly = migrationsAssemblyProperty.GetValue(relationalExtension) as string;
+        migrationsAssembly.ShouldBe(typeof(TestDbContext).Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void UseSharedSqlServer_AppliesCustomRetryValues()
+    {
+        DbContextOptionsBuilder<TestDbContext> optionsBuilder = new();
+
+        optionsBuilder.UseSharedSqlServer<TestDbContext>(
+            "Server=.;Database=DefaultDb;Trusted_Connection=True;",
+            retryOptions =>
+            {
+                retryOptions.MaxRetryCount = 3;
+                retryOptions.MaxRetryDelay = TimeSpan.FromSeconds(5);
+                retryOptions.AdditionalTransientErrorNumbers = new[] { 4060, 10928 };
+            });
+
+        using TestDbContext context = new(optionsBuilder.Options);
+
+        SqlServerRetryingExecutionStrategy executionStrategy =
+            context.Database.CreateExecutionStrategy() as SqlServerRetryingExecutionStrategy
+            ?? throw new InvalidOperationException("Expected SQL Server retrying execution strategy.");
+
+        executionStrategy.MaxRetryCount.ShouldBe(3);
+        executionStrategy.MaxRetryDelay.ShouldBe(TimeSpan.FromSeconds(5));
+        executionStrategy.AdditionalErrorNumbers.ShouldBe(new[] { 4060, 10928 });
+    }
+
+    [Fact]
+    public void SqlServerRetryOptions_ExposeRetryConfigurationShape()
+    {
+        SqlServerRetryOptions options = new()
+        {
+            MaxRetryCount = 9,
+            MaxRetryDelay = TimeSpan.FromSeconds(12),
+            AdditionalTransientErrorNumbers = new[] { 1, 2, 3 }
+        };
+
+        options.MaxRetryCount.ShouldBe(9);
+        options.MaxRetryDelay.ShouldBe(TimeSpan.FromSeconds(12));
+        options.AdditionalTransientErrorNumbers.ShouldBe(new[] { 1, 2, 3 });
+    }
+}

--- a/Shared/EntityFramework/DbContextResolver.cs
+++ b/Shared/EntityFramework/DbContextResolver.cs
@@ -47,7 +47,7 @@ public class DbContextResolver<TContext> : IDbContextResolver<TContext> where TC
 
             // Create an isolated service collection and provider
             ServiceCollection services = new();
-            services.AddDbContext<TContext>(options => { options.UseSqlServer(connectionString); });
+            services.AddDbContext<TContext>(options => { options.UseSharedSqlServer<TContext>(connectionString); });
 
             ServiceProvider provider = services.BuildServiceProvider();
             scope = provider.CreateScope();

--- a/Shared/EntityFramework/SqlServerDbContextOptionsBuilderExtensions.cs
+++ b/Shared/EntityFramework/SqlServerDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shared.EntityFramework;
+
+public sealed class SqlServerRetryOptions
+{
+    public int? MaxRetryCount { get; set; }
+
+    public TimeSpan? MaxRetryDelay { get; set; }
+
+    public ICollection<int>? AdditionalTransientErrorNumbers { get; set; }
+}
+
+public static class SqlServerDbContextOptionsBuilderExtensions
+{
+    private const int DefaultMaxRetryCount = 6;
+    private static readonly TimeSpan DefaultMaxRetryDelay = TimeSpan.FromSeconds(30);
+
+    public static DbContextOptionsBuilder UseSharedSqlServer<TContext>(
+        this DbContextOptionsBuilder optionsBuilder,
+        string connectionString,
+        Action<SqlServerRetryOptions>? configureRetryOptions = null)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        SqlServerRetryOptions retryOptions = new();
+        configureRetryOptions?.Invoke(retryOptions);
+
+        string migrationsAssembly = typeof(TContext).Assembly.GetName().Name
+            ?? throw new InvalidOperationException(
+                $"Unable to determine the migrations assembly for '{typeof(TContext).FullName}'.");
+
+        optionsBuilder.UseSqlServer(connectionString, sqlServerOptions =>
+        {
+            sqlServerOptions.MigrationsAssembly(migrationsAssembly);
+            ApplyRetryOptions(sqlServerOptions, retryOptions);
+        });
+
+        return optionsBuilder;
+    }
+
+    private static void ApplyRetryOptions(
+        SqlServerDbContextOptionsBuilder sqlServerOptions,
+        SqlServerRetryOptions retryOptions)
+    {
+        bool hasCustomRetryValues = retryOptions.MaxRetryCount.HasValue
+            || retryOptions.MaxRetryDelay.HasValue
+            || retryOptions.AdditionalTransientErrorNumbers is not null;
+
+        if (!hasCustomRetryValues)
+            return;
+
+        int maxRetryCount = retryOptions.MaxRetryCount ?? DefaultMaxRetryCount;
+        TimeSpan maxRetryDelay = retryOptions.MaxRetryDelay ?? DefaultMaxRetryDelay;
+        int[] additionalTransientErrorNumbers = retryOptions.AdditionalTransientErrorNumbers?.ToArray() ?? Array.Empty<int>();
+
+        sqlServerOptions.EnableRetryOnFailure(maxRetryCount, maxRetryDelay, additionalTransientErrorNumbers);
+    }
+}


### PR DESCRIPTION
Implements the shared SQL Server EF helper for centralized migrations assembly and optional retry configuration.

Closes #1295.